### PR TITLE
support CORS on cli and with env var

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
    - werkzeug >=0.15, <2.0
    - python-dateutil
    - flask-restx
+   - flask-cors
   build:
    - python >=3.5, <3.9
    - setuptools

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ install_requires=[
     'flask',
     'werkzeug>=0.15,<2.0',
     'flask-restx',
+    'flask-cors',
     'python-dateutil'
 ]
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -42,3 +42,13 @@ def test_content_length():
 
     app = make_app(funcs, 'cheese', max_content_length=1024)
     assert app.config['MAX_CONTENT_LENGTH'] == 1024
+
+def test_cors_star():
+    here = dirname(__file__)
+    fn = join(here, 'cheese_shop.py')
+    script = ScriptHandler(fn)
+    script.parse()
+    funcs = script.tranquilized_functions
+
+    app = make_app(funcs, 'cheese', origins='*')
+    assert app.after_request_funcs

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,6 +52,18 @@ def test_url_prefix():
     args = cli().parse_args([fn, '--prefix', 'python'])
     assert args.prefix == 'python'
 
+def test_cors_arg():
+    here = dirname(__file__)
+    fn = join(here, 'cheese_shop.py')
+    args = cli().parse_args([fn, '--allow-origin', '*'])
+    assert args.allow_origin == ['*']
+
+def test_cors_args():
+    here = dirname(__file__)
+    fn = join(here, 'cheese_shop.py')
+    args = cli().parse_args([fn, '--allow-origin', 'localhost', '--allow-origin', '127.0.0.1'])
+    assert args.allow_origin == ['localhost', '127.0.0.1']
+
 def test_debug():
     here = dirname(__file__)
     fn = join(here, 'cheese_shop.py')

--- a/tranquilizer/application.py
+++ b/tranquilizer/application.py
@@ -1,12 +1,16 @@
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 from flask_restx import Api, Namespace
+from flask_cors import CORS
+from os.path import join
 
 from .resource import make_resource
 
-def make_app(functions, name, prefix='/', max_content_length=None):
+def make_app(functions, name, prefix='/', max_content_length=None, origins=None):
     api = Api(title=name)
     app = Flask(__name__)
+    if origins is not None:
+        CORS(app, resources={r'{}'.format(join('/', prefix, '*')): {"origins": origins}})
     app.config['PREFERRED_URL_SCHEME'] = 'https'
     if max_content_length is not None:
         app.config['MAX_CONTENT_LENGTH'] = max_content_length


### PR DESCRIPTION
supply multiple --allow-origin HOST[:PORT] for each origin

alternatively, the variable TRANQUILIZER_ALLOW_ORIGIN will override
the cli flag. It takes a comma separated list of HOST[:PORT]

TRANQUILIZER_ALLOW_ORIGIN='localhost:8080,localhost:5000'