### PR TITLE
Support python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package is available for all Mac, Linux, and Windows on my conda channel. Py
 
 Tranquilizer can be used with either Jupyter Notebooks (`.ipynb`) or Python script files (`.py`).
 
-The decorated function below will be served as an end point called `cheese` with the GET method. The
+The decorated function below will be served as an end point called `order` with the GET method. The
 function must return a JSON serializable object.
 
 See the [complete description of `@tranquilize()`](#tranquilize-decorator) below.
@@ -28,7 +28,7 @@ def order(cheese):
     return "I'm afraid we're fresh out of {}, Sir.".format(cheese)
 ```
 
-The REST API is served by [Flask](http://flask.pocoo.org/) and [Flask-RESTX](https://flask-restx.readthedocs.io/en/latest/)
+The REST API is served by [Flask](https://flask.palletsprojects.com) and [Flask-RESTX](https://flask-restx.readthedocs.io/en/latest/)
 using the `tranquilizer` command.
 
 
@@ -64,7 +64,7 @@ Out[3]: '"I\'m afraid we\'re fresh out of cheddar, Sir."\n'
 The *tranquilized* API is documented with [Swagger](https://swagger.io/tools/open-source/) and is accessible
 in your web browser at [http://localhost:8086](http://localhost:8086).
 
-![](img/swagger.png)
+![](https://raw.githubusercontent.com/ContinuumIO/tranquilizer/9b4a738d1f24af7f4c2397d43454e0fe2ee5e86b/img/swagger.png)
 
 ## Tranquilize Decorator
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,14 +17,14 @@ build:
 
 requirements:
   run:
-   - python >=3.5, <3.9
+   - python >=3.5, <3.10
    - flask
    - werkzeug >=0.15, <2.0
    - python-dateutil
    - flask-restx
    - flask-cors
   build:
-   - python >=3.5, <3.9
+   - python >=3.5, <3.10
    - setuptools
 
 test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ addopts =
     --cov-report=term-missing
     --cov-report=xml:cov.xml
     --tb native
-    --strict
+    --strict-markers
     --durations=20
 env =
     PYTHONHASHSEED=0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "Intended Audience :: Developers",
         "Environment :: Web Environment"
     ],
-    python_requires=">=3.5, <3.9",
+    python_requires=">=3.5, <3.10",
     install_requires=install_requires,
     extras_require=extras_require,
     include_package_data=True,

--- a/tranquilizer/decorator.py
+++ b/tranquilizer/decorator.py
@@ -1,10 +1,10 @@
 from inspect import signature
 import re
 
-PARAM_REGEX = re.compile(":param (?P<name>[\*\w]+): (?P<doc>.*?)"
-                         "(?:(?=:param)|(?=:return)|(?=:raises)|\Z)", re.S)
-RAISE_REGEX = re.compile(":raise[s]? (?P<name>[\*\w]+): (?P<doc>.*?)"
-                         "(?:(?=:param)|(?=:return)|(?=:raise[s]?)|\Z)", re.S)
+PARAM_REGEX = re.compile(r":param (?P<name>[\*\w]+): (?P<doc>.*?)"
+                         r"(?:(?=:param)|(?=:return)|(?=:raises)|\Z)", re.S)
+RAISE_REGEX = re.compile(r":raise[s]? (?P<name>[\*\w]+): (?P<doc>.*?)"
+                         r"(?:(?=:param)|(?=:return)|(?=:raise[s]?)|\Z)", re.S)
 
 def _prepare_arg(arg):
     '''Return a keyword arg spec (dict)'''


### PR DESCRIPTION
(I did not see #26 before opening this PR, feel free to close mine!)

I attempted to install `tranquilizer` with pip in a Python 3.9 environment and ended up with a few horrific error messages and pip installing the version `0.0.5` 😄 

I've bumped the pins to support Python 3.9 and ran the test suite successfully in a conda env with the packages pulled from `defaults`. Tried Python 3.10 too but all the dependencies are not yet available on `defaults` (they must be on conda-forge thought, and pypi). Out of curiosity, what's the reason for pinning the upper Python version supported?

This PR also contains a few changes that remove warnings emitted during the test suite execution, and make a few minor changes to the README.