### PR TITLE
release werkzeug pin

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
    - python >=3.6, <3.10
    - flask
-   - werkzeug >=0.15, <2.0
+   - werkzeug >=0.15
    - python-dateutil
    - flask-restx
    - flask-cors

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8
   - flask
-  - werkzeug
+  - werkzeug>=0.15
   - python-dateutil
   - flask-restx
   - pytest
@@ -16,5 +16,5 @@ dependencies:
   - ipykernel
   - requests
   - flask-jwt-extended>=4
-  - werkzeug<2
+  - werkzeug
   - flask-cors

--- a/etc/test-environment.yml
+++ b/etc/test-environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
 dependencies:
   - flask
-  - werkzeug<2
+  - werkzeug>=0.15
   - python-dateutil
   - flask-restx
   - flask-cors

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 install_requires=[
     'flask',
-    'werkzeug>=0.15,<2.0',
+    'werkzeug>=0.15',
     'flask-restx',
     'flask-cors',
     'python-dateutil',


### PR DESCRIPTION
There was an issue with markupsafe (some deep dependency of tranquilizer) on the[ conda-forge feedstock](https://github.com/conda-forge/tranquilizer-feedstock/pull/20/checks). I hope by removing the pin it will help things along.