### PR TITLE
Do not install the tests as a top level package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ include MANIFEST.in
 
 include versioneer.py
 include tranquilizer/_version.py
+
+graft tests

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     platforms=['Windows', 'Mac OS X', 'Linux'],
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     entry_points={
         'console_scripts': [
             'tranquilizer = tranquilizer.main:run'


### PR DESCRIPTION
I noticed `tranquilizer` was distributing its `tests` folder as a top level package, i.e. it's in my `site-packages` folder. This happens because `find_packages()` look for folders that contain an `__init__.py` file, which is the case here. This PR excludes it. It also adds the `tests` folder to the source distribution by modifying th `MANIFEST.in`.
